### PR TITLE
[Hotfix]: generate prf code null when first data created

### DIFF
--- a/app/Services/JournalEntryService.php
+++ b/app/Services/JournalEntryService.php
@@ -228,12 +228,16 @@ class JournalEntryService
         $lastJournal = JournalEntry::whereNull('deleted_at')
             ->orderBy('id', 'desc')
             ->first();
-        $lastSeries = (int) substr($lastJournal->journal_no, -4); // Get last 4 digits
-        $nextSeries = $lastSeries + 1;
-        // Format the series number to be 4 digits (e.g., 0001)
-        $paddedSeries = str_pad($nextSeries, 4, '0', STR_PAD_LEFT);
-        // Construct the new reference number
-        $journalNo = "{$prefix}-{$currentYearMonth}-{$paddedSeries}";
+        if ($lastJournal) {
+            $lastSeries = (int) substr($lastJournal->journal_no, -4); // Get last 4 digits
+            $nextSeries = $lastSeries + 1;
+            // Format the series number to be 4 digits (e.g., 0001)
+            $paddedSeries = str_pad($nextSeries, 4, '0', STR_PAD_LEFT);
+            // Construct the new reference number
+            $journalNo = "{$prefix}-{$currentYearMonth}-{$paddedSeries}";
+        } else {
+            $journalNo = "{$prefix}-{$currentYearMonth}-0001";
+        }
 
         return $journalNo;
     }

--- a/app/Services/PaymentServices.php
+++ b/app/Services/PaymentServices.php
@@ -165,12 +165,16 @@ class PaymentServices
         $lastPaymentRequest = PaymentRequest::whereNull('deleted_at')
             ->orderBy('id', 'desc')
             ->first();
-        $lastSeries = (int) substr($lastPaymentRequest->prf_no, -4); // Get last 4 digits
-        $nextSeries = $lastSeries + 1;
-        // Format the series number to be 4 digits (e.g., 0001)
-        $paddedSeries = str_pad($nextSeries, 4, '0', STR_PAD_LEFT);
-        // Construct the new reference number
-        $prfNo = "{$prefix}-{$currentYearMonth}-{$paddedSeries}";
+        if ($lastPaymentRequest) {
+            $lastSeries = (int) substr($lastPaymentRequest->prf_no, -4); // Get last 4 digits
+            $nextSeries = $lastSeries + 1;
+            // Format the series number to be 4 digits (e.g., 0001)
+            $paddedSeries = str_pad($nextSeries, 4, '0', STR_PAD_LEFT);
+            // Construct the new reference number
+            $prfNo = "{$prefix}-{$currentYearMonth}-{$paddedSeries}";
+        } else {
+            $prfNo = "{$prefix}-{$currentYearMonth}-0001";
+        }
 
         return $prfNo;
     }

--- a/app/Services/VoucherService.php
+++ b/app/Services/VoucherService.php
@@ -24,12 +24,16 @@ class VoucherService
             ->where('type', $prefix == 'DV' ? VoucherType::DISBURSEMENT->value : VoucherType::CASH->value)
             ->orderBy('id', 'desc')
             ->first();
-        $lastSeries = (int) substr($lastVoucher->voucher_no, -4);
-        $nextSeries = $lastSeries + 1;
-        // Format the series number to be 4 digits (e.g., 0001)
-        $paddedSeries = str_pad($nextSeries, 4, '0', STR_PAD_LEFT);
-        // Construct the new reference number
-        $voucherNo = "{$prefix}-{$currentYearMonth}-{$paddedSeries}";
+        if ($lastVoucher) {
+            $lastSeries = (int) substr($lastVoucher->voucher_no, -4);
+            $nextSeries = $lastSeries + 1;
+            // Format the series number to be 4 digits (e.g., 0001)
+            $paddedSeries = str_pad($nextSeries, 4, '0', STR_PAD_LEFT);
+            // Construct the new reference number
+            $voucherNo = "{$prefix}-{$currentYearMonth}-{$paddedSeries}";
+        } else {
+            $voucherNo = "{$prefix}-{$currentYearMonth}-0001";
+        }
 
         return $voucherNo;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when generating journal, payment request, and voucher numbers by ensuring correct handling when no previous entries exist, preventing potential errors and ensuring proper numbering starts at "0001" when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->